### PR TITLE
Повышение версии guzzlehttp/guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "guzzlehttp/guzzle": "~6.0",
+    "guzzlehttp/guzzle": "^6.0",
     "ext-json": "*"
   },
   "autoload": {


### PR DESCRIPTION
Некоторые современные пакеты требуют guzzlehttp/guzzle версии 7 и выше.